### PR TITLE
Create tasks tests

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,10 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: test-environment
+  database: ruby-getting-started_test
+
+
+  # database: test-environment
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: ruby-getting-started_test
+  database: test-environment
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/db/migrate/20171106023658_add_description_to_groups.rb
+++ b/db/migrate/20171106023658_add_description_to_groups.rb
@@ -1,5 +1,5 @@
 class AddDescriptionToGroups < ActiveRecord::Migration
-  def change
-    add_column :groups, :description, :string
-  end
+  # def change
+  #   add_column :groups, :description, :string
+  # end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,9 +47,9 @@ ActiveRecord::Schema.define(version: 20171106023658) do
 
   create_table "groups", force: :cascade do |t|
     t.string   "name"
+    t.string   "description"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
-    t.string   "description"
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 class TaskTest < ActiveSupport::TestCase
+  # fixtures :tasks
   # test "the truth" do
   #   assert true
   # end
@@ -13,9 +14,23 @@ class TaskTest < ActiveSupport::TestCase
   # end
 
 
-  test "should report error" do
-    # some_undefined_variable is not defined elsewhere in the test case
-    # some_undefined_variable
-    assert true
+  # def test_true
+  #   assert true
+  # end
+
+  test "title must not be empty" do
+    task = Task.new('created_by' => 'Bob', 'state' => 'open')
+    assert(task.invalid?, 'task title cannot be nil')
   end
+
+  test "created by cannot be empty" do
+    task = Task.new('title' => 'write tests', 'state' => 'in progress')
+    assert(task.invalid?, 'task creator field cannot be nil')
+  end
+
+  test "state field cannot be empty" do
+    task = Task.new('title' => 'write tests', 'created_by' => 'Smith')
+    assert(task.invalid?, 'state field cannot be nil')
+  end
+
 end


### PR DESCRIPTION
- wrote 3 unit tests for tasks_test.rb 

- commented out add_description_to_groups migration in add_description_to_groups.rb because groups relation already has a column called descriptions, so adding that migration causes duplication errors 