### PR TITLE
Fix is_admin bug on sign up page

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -35,9 +35,10 @@
             </div>
             <!-- comment in and out this code to create admin accounts -->
             <!-- <div class="field"> -->
-              <%#= f.label :is_admin %><br>
+              <!-- <%#= f.label :is_admin %><br> -->
               <%#= f.check_box :is_admin %>
             <!-- </div> -->
+            <%= f.hidden_field :is_admin, :value => false %>
             <br/>
             <div class="actions">
               <%= f.submit('Signup', :class=>"btn btn-sm btn-success", :style=>"cursor:pointer")%>


### PR DESCRIPTION
Added a hidden_field in the sign up page to set is_admin to false for new users. (Currently, there's a bug where the is_admin field isn't being set at all.